### PR TITLE
fix(ci): Grant necessary permissions for labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,21 +5,19 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize]
 
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-
 jobs:
   label:
     name: Auto-label PRs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
       - name: Label PR based on title
         uses: release-drafter/release-drafter@v6.1.0
         with:
           disable-releaser: true
           config-name: release-drafter.yml
-          commitish: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,18 +1,18 @@
----
 name: Labeler
 
 on:
   pull_request_target:
-    types: [opened, edited, synchronize]
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
 
 jobs:
   label:
     name: Auto-label PRs
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
     steps:
       - name: Label PR based on title
         uses: release-drafter/release-drafter@v6.1.0

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,8 +1,9 @@
-name: Labeler
+---
+name: PR Labeler
 
 on:
   pull_request_target:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, edited, synchronize, reopened]
 
 permissions:
   contents: read
@@ -13,7 +14,14 @@ jobs:
   label:
     name: Auto-label PRs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
+      - name: Checkout repository for config
+        uses: actions/checkout@v4
+
       - name: Label PR based on title
         uses: release-drafter/release-drafter@v6.1.0
         with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,12 +3,7 @@ name: PR Labeler
 
 on:
   pull_request_target:
-    types: [opened, edited, synchronize, reopened]
-
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
+    types: [opened, edited, synchronize]
 
 jobs:
   label:
@@ -19,9 +14,6 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - name: Checkout repository for config
-        uses: actions/checkout@v4
-
       - name: Label PR based on title
         uses: release-drafter/release-drafter@v6.1.0
         with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,5 +20,6 @@ jobs:
         with:
           disable-releaser: true
           config-name: release-drafter.yml
+          commitish: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   label:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,6 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: Draft and Publish Release
         uses: release-drafter/release-drafter@v6.1.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Draft and Publish Release
         uses: release-drafter/release-drafter@v6.1.0
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,5 +98,5 @@ where = ["src"]
 # --------------------------------- Codespell ----------------------------------
 [tool.codespell]
 skip = "*.lock,*.json,*.svg"
-ignore-words-list = "sur,alo,larg,gam,hig"
+ignore-words-list = "sur,alo,larg,gam,hig,commitish"
 quiet-level = 2


### PR DESCRIPTION
## Proposed Changes

-   Resolves the `HttpError: You do not have permission to create labels on this repository.` error in the `labeler` GitHub Actions workflow.
-   The `release-drafter/release-drafter` action, when used for auto-labeling, requires `issues: write` permission in addition to `pull-requests: write` to successfully modify labels on pull requests.
-   Updated `.github/workflows/labeler.yml` to explicitly grant `issues: write` permissions to the `label` job.

## Readiness Checklist

### Author

-   [x] My code follows the style guidelines of this project.
-   [x] I have performed a self-review of my own code.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [ ] I have added tests that prove my fix is effective or that my feature works.
-   [x] New and existing unit tests pass locally with my changes.